### PR TITLE
add jsx-runtime and jsx-dev-runtime (#18299)

### DIFF
--- a/packages/react/index.classic.fb.js
+++ b/packages/react/index.classic.fb.js
@@ -50,8 +50,5 @@ export {
   DEPRECATED_createResponder,
   // enableScopeAPI
   unstable_createScope,
-  // enableJSXTransformAPI
-  jsx,
-  jsxs,
-  jsxDEV,
 } from './src/React';
+export {jsx, jsxs, jsxDEV} from './src/jsx/ReactJSX';

--- a/packages/react/index.experimental.js
+++ b/packages/react/index.experimental.js
@@ -45,8 +45,5 @@ export {
   unstable_withSuspenseConfig,
   // enableBlocksAPI
   block,
-  // enableJSXTransformAPI
-  jsx,
-  jsxs,
-  jsxDEV,
 } from './src/React';
+export {jsx, jsxs, jsxDEV} from './src/jsx/ReactJSX';

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -76,7 +76,5 @@ export {
   DEPRECATED_createResponder,
   unstable_createFundamental,
   unstable_createScope,
-  jsx,
-  jsxs,
-  jsxDEV,
 } from './src/React';
+export {jsx, jsxs, jsxDEV} from './src/jsx/ReactJSX';

--- a/packages/react/index.modern.fb.js
+++ b/packages/react/index.modern.fb.js
@@ -49,8 +49,5 @@ export {
   DEPRECATED_createResponder,
   // enableScopeAPI
   unstable_createScope,
-  // enableJSXTransformAPI
-  jsx,
-  jsxs,
-  jsxDEV,
 } from './src/React';
+export {jsx, jsxs, jsxDEV} from './src/jsx/ReactJSX';

--- a/packages/react/jsx-dev-runtime.js
+++ b/packages/react/jsx-dev-runtime.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export {Fragment, jsxDEV} from './src/jsx/ReactJSX';

--- a/packages/react/jsx-runtime.js
+++ b/packages/react/jsx-runtime.js
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+export {Fragment, jsx, jsxs} from './src/jsx/ReactJSX';

--- a/packages/react/npm/jsx-dev-runtime.js
+++ b/packages/react/npm/jsx-dev-runtime.js
@@ -1,0 +1,7 @@
+'use strict';
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./cjs/react-jsx-dev-runtime.production.min.js');
+} else {
+  module.exports = require('./cjs/react-jsx-dev-runtime.development.js');
+}

--- a/packages/react/npm/jsx-runtime.js
+++ b/packages/react/npm/jsx-runtime.js
@@ -1,0 +1,7 @@
+'use strict';
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./cjs/react-jsx-runtime.production.min.js');
+} else {
+  module.exports = require('./cjs/react-jsx-runtime.development.js');
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -14,7 +14,9 @@
     "build-info.json",
     "index.js",
     "cjs/",
-    "umd/"
+    "umd/",
+    "jsx-runtime.js",
+    "jsx-dev-runtime.js"
   ],
   "main": "index.js",
   "repository": {

--- a/packages/react/src/React.js
+++ b/packages/react/src/React.js
@@ -24,7 +24,6 @@ import {
   createFactory as createFactoryProd,
   cloneElement as cloneElementProd,
   isValidElement,
-  jsx as jsxProd,
 } from './ReactElement';
 import {createContext} from './ReactContext';
 import {lazy} from './ReactLazy';
@@ -52,9 +51,6 @@ import {
   createElementWithValidation,
   createFactoryWithValidation,
   cloneElementWithValidation,
-  jsxWithValidation,
-  jsxWithValidationStatic,
-  jsxWithValidationDynamic,
 } from './ReactElementValidator';
 import createMutableSource from './createMutableSource';
 import ReactSharedInternals from './ReactSharedInternals';
@@ -66,12 +62,6 @@ import createScope from 'shared/createScope';
 const createElement = __DEV__ ? createElementWithValidation : createElementProd;
 const cloneElement = __DEV__ ? cloneElementWithValidation : cloneElementProd;
 const createFactory = __DEV__ ? createFactoryWithValidation : createFactoryProd;
-
-const jsxDEV = __DEV__ ? jsxWithValidation : undefined;
-const jsx = __DEV__ ? jsxWithValidationDynamic : jsxProd;
-// we may want to special case jsxs internally to take advantage of static children.
-// for now we can ship identical prod functions
-const jsxs = __DEV__ ? jsxWithValidationStatic : jsxProd;
 
 const Children = {
   map,
@@ -127,9 +117,4 @@ export {
   createFundamental as unstable_createFundamental,
   // enableScopeAPI
   createScope as unstable_createScope,
-  // enableJSXTransformAPI
-  jsx,
-  jsxs,
-  // TODO: jsxDEV should not be exposed as a name. We might want to move it to a different entry point.
-  jsxDEV,
 };

--- a/packages/react/src/ReactDebugCurrentFrame.js
+++ b/packages/react/src/ReactDebugCurrentFrame.js
@@ -23,6 +23,13 @@ export function setCurrentlyValidatingElement(element: null | ReactElement) {
 }
 
 if (__DEV__) {
+  ReactDebugCurrentFrame.setCurrentlyValidatingElement = function(
+    element: null | ReactElement,
+  ) {
+    if (__DEV__) {
+      currentlyValidatingElement = element;
+    }
+  };
   // Stack implementation injected by the current renderer.
   ReactDebugCurrentFrame.getCurrentStack = (null: null | (() => string));
 

--- a/packages/react/src/jsx/ReactJSX.js
+++ b/packages/react/src/jsx/ReactJSX.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+import {REACT_FRAGMENT_TYPE} from 'shared/ReactSymbols';
+import {
+  jsxWithValidationStatic,
+  jsxWithValidationDynamic,
+  jsxWithValidation,
+} from './ReactJSXElementValidator';
+import {jsx as jsxProd} from './ReactJSXElement';
+const jsx = __DEV__ ? jsxWithValidationDynamic : jsxProd;
+// we may want to special case jsxs internally to take advantage of static children.
+// for now we can ship identical prod functions
+const jsxs = __DEV__ ? jsxWithValidationStatic : jsxProd;
+const jsxDEV = __DEV__ ? jsxWithValidation : undefined;
+
+export {REACT_FRAGMENT_TYPE as Fragment, jsx, jsxs, jsxDEV};

--- a/packages/react/src/jsx/ReactJSXElement.js
+++ b/packages/react/src/jsx/ReactJSXElement.js
@@ -1,0 +1,319 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import getComponentName from 'shared/getComponentName';
+import ReactSharedInternals from 'shared/ReactSharedInternals';
+import {REACT_ELEMENT_TYPE} from 'shared/ReactSymbols';
+const ReactCurrentOwner = ReactSharedInternals.ReactCurrentOwner;
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+const RESERVED_PROPS = {
+  key: true,
+  ref: true,
+  __self: true,
+  __source: true,
+};
+let specialPropKeyWarningShown,
+  specialPropRefWarningShown,
+  didWarnAboutStringRefs;
+if (__DEV__) {
+  didWarnAboutStringRefs = {};
+}
+function hasValidRef(config) {
+  if (__DEV__) {
+    if (hasOwnProperty.call(config, 'ref')) {
+      const getter = Object.getOwnPropertyDescriptor(config, 'ref').get;
+      if (getter && getter.isReactWarning) {
+        return false;
+      }
+    }
+  }
+  return config.ref !== undefined;
+}
+function hasValidKey(config) {
+  if (__DEV__) {
+    if (hasOwnProperty.call(config, 'key')) {
+      const getter = Object.getOwnPropertyDescriptor(config, 'key').get;
+      if (getter && getter.isReactWarning) {
+        return false;
+      }
+    }
+  }
+  return config.key !== undefined;
+}
+function warnIfStringRefCannotBeAutoConverted(config) {
+  if (__DEV__) {
+    if (
+      typeof config.ref === 'string' &&
+      ReactCurrentOwner.current &&
+      config.__self &&
+      ReactCurrentOwner.current.stateNode !== config.__self
+    ) {
+      const componentName = getComponentName(ReactCurrentOwner.current.type);
+      if (!didWarnAboutStringRefs[componentName]) {
+        console.error(
+          'Component "%s" contains the string ref "%s". ' +
+            'Support for string refs will be removed in a future major release. ' +
+            'This case cannot be automatically converted to an arrow function. ' +
+            'We ask you to manually fix this case by using useRef() or createRef() instead. ' +
+            'Learn more about using refs safely here: ' +
+            'https://fb.me/react-strict-mode-string-ref',
+          getComponentName(ReactCurrentOwner.current.type),
+          config.ref,
+        );
+        didWarnAboutStringRefs[componentName] = true;
+      }
+    }
+  }
+}
+function defineKeyPropWarningGetter(props, displayName) {
+  const warnAboutAccessingKey = function() {
+    if (__DEV__) {
+      if (!specialPropKeyWarningShown) {
+        specialPropKeyWarningShown = true;
+        console.error(
+          '%s: `key` is not a prop. Trying to access it will result ' +
+            'in `undefined` being returned. If you need to access the same ' +
+            'value within the child component, you should pass it as a different ' +
+            'prop. (https://fb.me/react-special-props)',
+          displayName,
+        );
+      }
+    }
+  };
+  warnAboutAccessingKey.isReactWarning = true;
+  Object.defineProperty(props, 'key', {
+    get: warnAboutAccessingKey,
+    configurable: true,
+  });
+}
+function defineRefPropWarningGetter(props, displayName) {
+  const warnAboutAccessingRef = function() {
+    if (__DEV__) {
+      if (!specialPropRefWarningShown) {
+        specialPropRefWarningShown = true;
+        console.error(
+          '%s: `ref` is not a prop. Trying to access it will result ' +
+            'in `undefined` being returned. If you need to access the same ' +
+            'value within the child component, you should pass it as a different ' +
+            'prop. (https://fb.me/react-special-props)',
+          displayName,
+        );
+      }
+    }
+  };
+  warnAboutAccessingRef.isReactWarning = true;
+  Object.defineProperty(props, 'ref', {
+    get: warnAboutAccessingRef,
+    configurable: true,
+  });
+}
+/**
+ * Factory method to create a new React element. This no longer adheres to
+ * the class pattern, so do not use new to call it. Also, instanceof check
+ * will not work. Instead test $$typeof field against Symbol.for('react.element') to check
+ * if something is a React Element.
+ *
+ * @param {*} type
+ * @param {*} props
+ * @param {*} key
+ * @param {string|object} ref
+ * @param {*} owner
+ * @param {*} self A *temporary* helper to detect places where `this` is
+ * different from the `owner` when React.createElement is called, so that we
+ * can warn. We want to get rid of owner and replace string `ref`s with arrow
+ * functions, and as long as `this` and owner are the same, there will be no
+ * change in behavior.
+ * @param {*} source An annotation object (added by a transpiler or otherwise)
+ * indicating filename, line number, and/or other information.
+ * @internal
+ */
+const ReactElement = function(type, key, ref, self, source, owner, props) {
+  const element = {
+    // This tag allows us to uniquely identify this as a React Element
+    $$typeof: REACT_ELEMENT_TYPE,
+    // Built-in properties that belong on the element
+    type: type,
+    key: key,
+    ref: ref,
+    props: props,
+    // Record the component responsible for creating this element.
+    _owner: owner,
+  };
+  if (__DEV__) {
+    // The validation flag is currently mutative. We put it on
+    // an external backing store so that we can freeze the whole object.
+    // This can be replaced with a WeakMap once they are implemented in
+    // commonly used development environments.
+    element._store = {};
+    // To make comparing ReactElements easier for testing purposes, we make
+    // the validation flag non-enumerable (where possible, which should
+    // include every environment we run tests in), so the test framework
+    // ignores it.
+    Object.defineProperty(element._store, 'validated', {
+      configurable: false,
+      enumerable: false,
+      writable: true,
+      value: false,
+    });
+    // self and source are DEV only properties.
+    Object.defineProperty(element, '_self', {
+      configurable: false,
+      enumerable: false,
+      writable: false,
+      value: self,
+    });
+    // Two elements created in two different places should be considered
+    // equal for testing purposes and therefore we hide it from enumeration.
+    Object.defineProperty(element, '_source', {
+      configurable: false,
+      enumerable: false,
+      writable: false,
+      value: source,
+    });
+    if (Object.freeze) {
+      Object.freeze(element.props);
+      Object.freeze(element);
+    }
+  }
+  return element;
+};
+/**
+ * https://github.com/reactjs/rfcs/pull/107
+ * @param {*} type
+ * @param {object} props
+ * @param {string} key
+ */
+export function jsx(type, config, maybeKey) {
+  let propName;
+  // Reserved names are extracted
+  const props = {};
+  let key = null;
+  let ref = null;
+  // Currently, key can be spread in as a prop. This causes a potential
+  // issue if key is also explicitly declared (ie. <div {...props} key="Hi" />
+  // or <div key="Hi" {...props} /> ). We want to deprecate key spread,
+  // but as an intermediary step, we will use jsxDEV for everything except
+  // <div {...props} key="Hi" />, because we aren't currently able to tell if
+  // key is explicitly declared to be undefined or not.
+  if (maybeKey !== undefined) {
+    key = '' + maybeKey;
+  }
+  if (hasValidKey(config)) {
+    key = '' + config.key;
+  }
+  if (hasValidRef(config)) {
+    ref = config.ref;
+  }
+  // Remaining properties are added to a new props object
+  for (propName in config) {
+    if (
+      hasOwnProperty.call(config, propName) &&
+      !RESERVED_PROPS.hasOwnProperty(propName)
+    ) {
+      props[propName] = config[propName];
+    }
+  }
+  // Resolve default props
+  if (type && type.defaultProps) {
+    const defaultProps = type.defaultProps;
+    for (propName in defaultProps) {
+      if (props[propName] === undefined) {
+        props[propName] = defaultProps[propName];
+      }
+    }
+  }
+  return ReactElement(
+    type,
+    key,
+    ref,
+    undefined,
+    undefined,
+    ReactCurrentOwner.current,
+    props,
+  );
+}
+/**
+ * https://github.com/reactjs/rfcs/pull/107
+ * @param {*} type
+ * @param {object} props
+ * @param {string} key
+ */
+export function jsxDEV(type, config, maybeKey, source, self) {
+  let propName;
+  // Reserved names are extracted
+  const props = {};
+  let key = null;
+  let ref = null;
+  // Currently, key can be spread in as a prop. This causes a potential
+  // issue if key is also explicitly declared (ie. <div {...props} key="Hi" />
+  // or <div key="Hi" {...props} /> ). We want to deprecate key spread,
+  // but as an intermediary step, we will use jsxDEV for everything except
+  // <div {...props} key="Hi" />, because we aren't currently able to tell if
+  // key is explicitly declared to be undefined or not.
+  if (maybeKey !== undefined) {
+    key = '' + maybeKey;
+  }
+  if (hasValidKey(config)) {
+    key = '' + config.key;
+  }
+  if (hasValidRef(config)) {
+    ref = config.ref;
+    warnIfStringRefCannotBeAutoConverted(config);
+  }
+  // Remaining properties are added to a new props object
+  for (propName in config) {
+    if (
+      hasOwnProperty.call(config, propName) &&
+      !RESERVED_PROPS.hasOwnProperty(propName)
+    ) {
+      props[propName] = config[propName];
+    }
+  }
+  // Resolve default props
+  if (type && type.defaultProps) {
+    const defaultProps = type.defaultProps;
+    for (propName in defaultProps) {
+      if (props[propName] === undefined) {
+        props[propName] = defaultProps[propName];
+      }
+    }
+  }
+  if (key || ref) {
+    const displayName =
+      typeof type === 'function'
+        ? type.displayName || type.name || 'Unknown'
+        : type;
+    if (key) {
+      defineKeyPropWarningGetter(props, displayName);
+    }
+    if (ref) {
+      defineRefPropWarningGetter(props, displayName);
+    }
+  }
+  return ReactElement(
+    type,
+    key,
+    ref,
+    self,
+    source,
+    ReactCurrentOwner.current,
+    props,
+  );
+}
+/**
+ * Verifies the object is a ReactElement.
+ * See https://reactjs.org/docs/react-api.html#isvalidelement
+ * @param {?object} object
+ * @return {boolean} True if `object` is a ReactElement.
+ * @final
+ */
+export function isValidElement(object) {
+  return (
+    typeof object === 'object' &&
+    object !== null &&
+    object.$$typeof === REACT_ELEMENT_TYPE
+  );
+}

--- a/scripts/rollup/bundles.js
+++ b/scripts/rollup/bundles.js
@@ -76,6 +76,38 @@ const bundles = [
     externals: [],
   },
 
+  /******* React JSX Runtime *******/
+  {
+    bundleTypes: [
+      NODE_DEV,
+      NODE_PROD,
+      NODE_PROFILING,
+      FB_WWW_DEV,
+      FB_WWW_PROD,
+      FB_WWW_PROFILING,
+    ],
+    moduleType: ISOMORPHIC,
+    entry: 'react/jsx-runtime',
+    global: 'JSXRuntime',
+    externals: ['react'],
+  },
+
+  /******* React JSX DEV Runtime *******/
+  {
+    bundleTypes: [
+      NODE_DEV,
+      NODE_PROD,
+      NODE_PROFILING,
+      FB_WWW_DEV,
+      FB_WWW_PROD,
+      FB_WWW_PROFILING,
+    ],
+    moduleType: ISOMORPHIC,
+    entry: 'react/jsx-dev-runtime',
+    global: 'JSXDEVRuntime',
+    externals: ['react'],
+  },
+
   /******* React DOM *******/
   {
     bundleTypes: [

--- a/scripts/rollup/forks.js
+++ b/scripts/rollup/forks.js
@@ -58,7 +58,7 @@ const forks = Object.freeze({
     if (entry === 'react') {
       return 'react/src/ReactSharedInternals';
     }
-    if (dependencies.indexOf('react') === -1) {
+    if (!entry.startsWith('react/') && dependencies.indexOf('react') === -1) {
       // React internals are unavailable if we can't reference the package.
       // We return an error because we only want to throw if this module gets used.
       return new Error(

--- a/scripts/rollup/modules.js
+++ b/scripts/rollup/modules.js
@@ -14,6 +14,7 @@ const importSideEffects = Object.freeze({
   scheduler: HAS_NO_SIDE_EFFECTS_ON_IMPORT,
   'scheduler/tracing': HAS_NO_SIDE_EFFECTS_ON_IMPORT,
   'react-dom/server': HAS_NO_SIDE_EFFECTS_ON_IMPORT,
+  'react/jsx-dev-runtime': HAS_NO_SIDE_EFFECTS_ON_IMPORT,
 });
 
 // Bundles exporting globals that other modules rely on.


### PR DESCRIPTION
This PR adds the jsx-runtime and jsx-dev-runtime modules for the JSX Babel Plugin. WWW still relies on jsx/jsxs/jsxDEV from the "react" module, so once we refactor the code to point to the runtime modules we will remove jsx/jsxs/jsxDEV from the "react" module.